### PR TITLE
Fix crash when $BROWSER is not set

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,9 @@ Relative to urlview, urlscan has the following additional features:
 
 - Jump to a URL by typing the number.
 
+- Execute an arbitrary function (for example, copy URL to clipboard) instead of
+  opening URL in a browser.
+
 Installation and setup
 ----------------------
 
@@ -59,7 +62,7 @@ Command Line usage
 
 ::
 
-    urlscan [-n, --no-browser] [-c, --compact] [-d, --dedupe] <file>
+    urlscan [-n, --no-browser] [-c, --compact] [-d, --dedupe] [-r, --run <expression>] <file>
 
 Urlscan can extract URLs and email addresses from emails or any text file. Calling with no flags will start the curses browser. Calling with '-n' will just output a list of URLs/email addressess to stdout. The '-c' flag removes the context from around the URLs in the curses browser, and the '-d' flag removes duplicate URLs. Files can also be piped to urlscan using normal shell pipe mechanisms: `cat <something> | urlscan` or `urlscan < <something>`
 

--- a/bin/urlscan
+++ b/bin/urlscan
@@ -49,6 +49,11 @@ def parse_arguments():
     arg_parse.add_argument('--dedupe', '-d', dest="dedupe",
                            action='store_true', default=False,
                            help="Remove duplicate URLs from list")
+    arg_parse.add_argument('--run', '-r',
+                           help="Alternate command to run on selected URL "
+                           "instead of opening URL in browser. Use {} to "
+                           "represent the URL value in the expression. "
+                           "For example: --run 'echo {} | xclip -i'")
     arg_parse.add_argument('message', nargs='?', default=sys.stdin,
                            help="Filename of the message to parse")
     args = arg_parse.parse_args()
@@ -166,7 +171,8 @@ if __name__ == "__main__":
     if args.nobrowser is False:
         ui = urlchoose.URLChooser(urlscan.msgurls(msg),
                                   compact=args.compact,
-                                  dedupe=args.dedupe)
+                                  dedupe=args.dedupe,
+                                  run=args.run)
         ui.main()
     else:
         out = urlchoose.URLChooser(urlscan.msgurls(msg),

--- a/urlscan.1
+++ b/urlscan.1
@@ -1,6 +1,6 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
 
-.TH URLSCAN 1 "February 26, 2017"
+.TH URLSCAN 1 "April 16, 2018"
 
 .SH NAME
 urlscan \- browse the URLs in an email message from a terminal
@@ -47,6 +47,12 @@ Remove duplicated URLs from the list of URLs.
 .B \-n, \-\-no-browser
 Disables the selection interface and print the links to standard output.
 Useful for scripting (implies \fB\-\-compact\fR).
+.TP
+.B \-r, \-\-run \<expression\>
+Execute \<expression\> in place of opening URL with a browser. Use {} in
+\<expression\> to substitute in the URL. Example:
+
+    $ urlscan --run 'echo {} | xclip -i' file.txt
 
 .SH MUTT INTEGRATION
 

--- a/urlscan/urlchoose.py
+++ b/urlscan/urlchoose.py
@@ -53,18 +53,17 @@ class URLChooser:
                           isinstance(i, urwid.Columns) is True]
         if self.compact is True:
             self.items, self.items_com = self.items_com, self.items
+        self.urls_unesc = [i.replace('\\', '') for i in self.urls]
+        self.unesc = False
         self.contents = urwid.SimpleFocusListWalker(self.items)
         listbox = urwid.ListBox(self.contents)
-        if len(self.urls) == 1:
-            header = 'Found 1 url.'
-        else:
-            header = 'Found %d urls.' % len(self.urls)
-        header = "{} :: {}".format(header, "q - Quit :: "
-                                   "c - context :: "
-                                   "s - URL short :: "
-                                   "S - all URL short :: "
-                                   "g/G - top/bottom :: "
-                                   "<number> - jump to <number> :: ")
+        header = (":: q - Quit :: "
+                  "c - context :: "
+                  "s - URL short :: "
+                  "S - all URL short :: "
+                  "g/G - top/bottom :: "
+                  "<num> - jump to <num> :: "
+                  "u - unescape URL ::")
         headerwid = urwid.AttrMap(urwid.Text(header), 'header')
         self.top = urwid.Frame(listbox, headerwid)
         if self.urls:
@@ -175,6 +174,15 @@ class URLChooser:
                 self.top.body = urwid.ListBox(self.items)
                 self.top.body.focus_position = self._cur_focus(fp)
                 self.compact = False if self.compact is True else True
+            elif k == 'u':
+                # Toggle removing escape characters from URL
+                self.unesc = False if self.compact is True else True
+                self.urls, self.urls_unesc = self.urls_unesc, self.urls
+                urls = iter(self.urls)
+                for item in self.items:
+                    # Each Column has (Text, Button). Update the Button label
+                    if isinstance(item, urwid.Columns):
+                        item[1].set_label(next(urls))
             else:
                 self.top.keypress(size, k)
 

--- a/urlscan/urlchoose.py
+++ b/urlscan/urlchoose.py
@@ -159,14 +159,12 @@ class URLChooser:
                 # Toggle all shortened URLs
                 self.shorten = False if self.shorten is True else True
                 urls = iter(self.urls)
-                columns_idx = 1
                 for item in self.items:
                     # Each Column has (Text, Button). Update the Button label
                     if isinstance(item, urwid.Columns):
                         item[1].set_label(shorten_url(next(urls),
                                                       size[0],
                                                       self.shorten))
-                        columns_idx += 1
             elif k == 'c':
                 # Show/hide context
                 fp = self.top.body.focus_position

--- a/urlscan/urlchoose.py
+++ b/urlscan/urlchoose.py
@@ -27,15 +27,6 @@ from threading import Thread
 from time import sleep
 
 
-def mkbrowseto(url):
-    """Create the urwid callback function to open the web browser.
-
-    """
-    def browse(*args):
-        webbrowser.open(url)
-    return browse
-
-
 def shorten_url(url, cols, shorten):
     """Shorten long URLs to fit on one line.
 
@@ -47,91 +38,13 @@ def shorten_url(url, cols, shorten):
     return url[:split] + "..." + url[-split:]
 
 
-def process_urls(extractedurls, dedupe, shorten):
-    """Process the 'extractedurls' and ready them for either the curses browser
-    or non-interactive output
-
-    Args: extractedurls
-          dedupe - Remove duplicate URLs from list
-
-    Returns: items - List of widgets for the ListBox
-             urls - List of all URLs
-
-    """
-    cols, _ = urwid.raw_display.Screen().get_cols_rows()
-    items = []
-    urls = []
-    first = True
-    for group, usedfirst, usedlast in extractedurls:
-        if first:
-            first = False
-        items.append(urwid.Divider(div_char='-', top=1, bottom=1))
-        if dedupe is True:
-            # If no unique URLs exist, then skip the group completely
-            if not [chunk for chunks in group for chunk in chunks
-                    if chunk.url is not None and chunk.url not in urls]:
-                continue
-        groupurls = []
-        markup = []
-        if not usedfirst:
-            markup.append(('msgtext:ellipses', '...\n'))
-        for chunks in group:
-            i = 0
-            while i < len(chunks):
-                chunk = chunks[i]
-                i += 1
-                if chunk.url is None:
-                    markup.append(chunk.markup)
-                else:
-                    if (dedupe is True and chunk.url not in urls) \
-                            or dedupe is False:
-                        urls.append(chunk.url)
-                        groupurls.append(chunk.url)
-                    # Collect all immediately adjacent
-                    # chunks with the same URL.
-                    tmpmarkup = []
-                    if chunk.markup:
-                        tmpmarkup.append(chunk.markup)
-                    while i < len(chunks) and \
-                            chunks[i].url == chunk.url:
-                        if chunks[i].markup:
-                            tmpmarkup.append(chunks[i].markup)
-                        i += 1
-                    url_idx = urls.index(chunk.url) + 1 if dedupe is True else len(urls)
-                    markup += [tmpmarkup or '<URL>',
-                               ('urlref:number:braces', ' ['),
-                               ('urlref:number', repr(url_idx)),
-                               ('urlref:number:braces', ']')]
-            markup += '\n'
-        if not usedlast:
-            markup += [('msgtext:ellipses', '...\n\n')]
-        items.append(urwid.Text(markup))
-
-        i = len(urls) - len(groupurls)
-        for url in groupurls:
-            i += 1
-            markup = [(6, urwid.Text([('urlref:number:braces', '['),
-                                      ('urlref:number', repr(i)),
-                                      ('urlref:number:braces', ']'),
-                                      ' '])),
-                      urwid.AttrMap(urwid.Button(shorten_url(url,
-                                                             cols,
-                                                             shorten),
-                                                 mkbrowseto(url),
-                                                 user_data=url),
-                                    'urlref:url', 'url:sel')]
-            items.append(urwid.Columns(markup))
-
-    return items, urls
-
-
 class URLChooser:
     def __init__(self, extractedurls, compact=False, dedupe=False, shorten=True):
         self.shorten = shorten
         self.compact = compact
-        self.items, self.urls = process_urls(extractedurls,
-                                             dedupe=dedupe,
-                                             shorten=self.shorten)
+        self.items, self.urls = self.process_urls(extractedurls,
+                                                  dedupe=dedupe,
+                                                  shorten=self.shorten)
         # Store 'compact' mode items
         self.items_com = [i for i in self.items if
                           isinstance(i, urwid.Columns) is True]
@@ -288,7 +201,7 @@ class URLChooser:
         # Return correct focus when toggling 'show context'
         if self.compact is False:
             idx = len([i for i in self.items_com[:fp + 1]
-                      if isinstance(i, urwid.Columns)]) - 1
+                       if isinstance(i, urwid.Columns)]) - 1
         elif self.compact is True:
             idx = [i for i in enumerate(self.items)
                    if isinstance(i[1], urwid.Columns)][fp][0]
@@ -298,3 +211,90 @@ class URLChooser:
         self.ui.clear()
         canvas = self.top.render(size, focus=True)
         self.ui.draw_screen(size, canvas)
+
+    def mkbrowseto(self, url):
+        """Create the urwid callback function to open the web browser.
+
+        """
+        def browse(*args):
+            webbrowser.open(url)
+            size = self.ui.get_cols_rows()
+            self.draw_screen(size)
+        return browse
+
+    def process_urls(self, extractedurls, dedupe, shorten):
+        """Process the 'extractedurls' and ready them for either the curses browser
+        or non-interactive output
+
+        Args: extractedurls
+              dedupe - Remove duplicate URLs from list
+
+        Returns: items - List of widgets for the ListBox
+                 urls - List of all URLs
+
+        """
+        cols, _ = urwid.raw_display.Screen().get_cols_rows()
+        items = []
+        urls = []
+        first = True
+        for group, usedfirst, usedlast in extractedurls:
+            if first:
+                first = False
+            items.append(urwid.Divider(div_char='-', top=1, bottom=1))
+            if dedupe is True:
+                # If no unique URLs exist, then skip the group completely
+                if not [chunk for chunks in group for chunk in chunks
+                        if chunk.url is not None and chunk.url not in urls]:
+                    continue
+            groupurls = []
+            markup = []
+            if not usedfirst:
+                markup.append(('msgtext:ellipses', '...\n'))
+            for chunks in group:
+                i = 0
+                while i < len(chunks):
+                    chunk = chunks[i]
+                    i += 1
+                    if chunk.url is None:
+                        markup.append(chunk.markup)
+                    else:
+                        if (dedupe is True and chunk.url not in urls) \
+                                or dedupe is False:
+                            urls.append(chunk.url)
+                            groupurls.append(chunk.url)
+                        # Collect all immediately adjacent
+                        # chunks with the same URL.
+                        tmpmarkup = []
+                        if chunk.markup:
+                            tmpmarkup.append(chunk.markup)
+                        while i < len(chunks) and \
+                                chunks[i].url == chunk.url:
+                            if chunks[i].markup:
+                                tmpmarkup.append(chunks[i].markup)
+                            i += 1
+                        url_idx = urls.index(chunk.url) + 1 if dedupe is True else len(urls)
+                        markup += [tmpmarkup or '<URL>',
+                                   ('urlref:number:braces', ' ['),
+                                   ('urlref:number', repr(url_idx)),
+                                   ('urlref:number:braces', ']')]
+                markup += '\n'
+            if not usedlast:
+                markup += [('msgtext:ellipses', '...\n\n')]
+            items.append(urwid.Text(markup))
+
+            i = len(urls) - len(groupurls)
+            for url in groupurls:
+                i += 1
+                markup = [(6, urwid.Text([('urlref:number:braces', '['),
+                                          ('urlref:number', repr(i)),
+                                          ('urlref:number:braces', ']'),
+                                          ' '])),
+                          urwid.AttrMap(urwid.Button(shorten_url(url,
+                                                                 cols,
+                                                                 shorten),
+                                                     self.mkbrowseto(url),
+                                                     user_data=url),
+                                        'urlref:url', 'url:sel')]
+                items.append(urwid.Columns(markup))
+
+        return items, urls

--- a/urlscan/urlchoose.py
+++ b/urlscan/urlchoose.py
@@ -82,10 +82,11 @@ def process_urls(extractedurls, dedupe, shorten):
                 i += 1
                 if chunk.url is None:
                     markup.append(chunk.markup)
-                elif (dedupe is True and chunk.url not in urls) \
-                        or dedupe is False:
-                    urls.append(chunk.url)
-                    groupurls.append(chunk.url)
+                else:
+                    if (dedupe is True and chunk.url not in urls) \
+                            or dedupe is False:
+                        urls.append(chunk.url)
+                        groupurls.append(chunk.url)
                     # Collect all immediately adjacent
                     # chunks with the same URL.
                     tmpmarkup = []
@@ -96,9 +97,10 @@ def process_urls(extractedurls, dedupe, shorten):
                         if chunks[i].markup:
                             tmpmarkup.append(chunks[i].markup)
                         i += 1
+                    url_idx = urls.index(chunk.url) + 1 if dedupe is True else len(urls)
                     markup += [tmpmarkup or '<URL>',
                                ('urlref:number:braces', ' ['),
-                               ('urlref:number', repr(len(urls))),
+                               ('urlref:number', repr(url_idx)),
                                ('urlref:number:braces', ']')]
             markup += '\n'
         if not usedlast:

--- a/urlscan/urlchoose.py
+++ b/urlscan/urlchoose.py
@@ -23,6 +23,7 @@ import urwid
 import urwid.curses_display
 import urwid.raw_display
 import webbrowser
+from subprocess import Popen
 from threading import Thread
 from time import sleep
 
@@ -39,9 +40,11 @@ def shorten_url(url, cols, shorten):
 
 
 class URLChooser:
-    def __init__(self, extractedurls, compact=False, dedupe=False, shorten=True):
+    def __init__(self, extractedurls, compact=False, dedupe=False, shorten=True,
+                 run=""):
         self.shorten = shorten
         self.compact = compact
+        self.run = run
         self.items, self.urls = self.process_urls(extractedurls,
                                                   dedupe=dedupe,
                                                   shorten=self.shorten)
@@ -100,8 +103,9 @@ class URLChooser:
         """
         for k in keys:
             if (k == 'enter' or k == ' ') and self.urls:
+                load_text = "Loading URL..." if not self.run else "Executing: {}".format(self.run)
                 if os.environ['BROWSER'] not in ['elinks', 'links', 'w3m', 'lynx']:
-                    self._footer_start_thread("Loading URL...", 5)
+                    self._footer_start_thread(load_text, 5)
         # filter backspace out before the widget, it has a weird interaction
         return [i for i in keys if i != 'backspace']
 
@@ -213,11 +217,15 @@ class URLChooser:
         self.ui.draw_screen(size, canvas)
 
     def mkbrowseto(self, url):
-        """Create the urwid callback function to open the web browser.
+        """Create the urwid callback function to open the web browser or call
+        another function with the URL.
 
         """
         def browse(*args):
-            webbrowser.open(url)
+            if not self.run:
+                webbrowser.open(url)
+            else:
+                Popen(self.run.format(url), shell=True).communicate()
             size = self.ui.get_cols_rows()
             self.draw_screen(size)
         return browse

--- a/urlscan/urlchoose.py
+++ b/urlscan/urlchoose.py
@@ -103,7 +103,7 @@ class URLChooser:
         for k in keys:
             if (k == 'enter' or k == ' ') and self.urls:
                 load_text = "Loading URL..." if not self.run else "Executing: {}".format(self.run)
-                if os.environ['BROWSER'] not in ['elinks', 'links', 'w3m', 'lynx']:
+                if os.environ.get('BROWSER') not in ['elinks', 'links', 'w3m', 'lynx']:
                     self._footer_start_thread(load_text, 5)
         # filter backspace out before the widget, it has a weird interaction
         return [i for i in keys if i != 'backspace']

--- a/urlscan/urlscan.py
+++ b/urlscan/urlscan.py
@@ -245,7 +245,7 @@ class HTMLChunker(HTMLParser):
             self.handle_data('&%s;' % name)
 
 
-urlinternalpattern = r'[{}()@\w/\-%?!&.=:;+,#~]'
+urlinternalpattern = r'[{}()@\w/\\\-%?!&.=:;+,#~]'
 urltrailingpattern = r'[{}(@\w/\-%&=+#]'
 httpurlpattern = (r'(?:(https?|file|ftps?)://' + urlinternalpattern +
                   r'*' + urltrailingpattern + r')')


### PR DESCRIPTION
Fixes

    Traceback (most recent call last):
      File "/home/mg/.venv/bin/urlscan", line 6, in <module>
        exec(compile(open(__file__).read(), __file__, 'exec'))
      File "/home/mg/src/urlscan/bin/urlscan", line 176, in <module>
        ui.main()
      File "/home/mg/src/urlscan/urlscan/urlchoose.py", line 97, in main
        loop.run()
      File "/home/mg/.venv/local/lib/python2.7/site-packages/urwid/main_loop.py", line 286, in run
        self._run()
      File "/home/mg/.venv/local/lib/python2.7/site-packages/urwid/main_loop.py", line 379, in _run
        return self._run_screen_event_loop()
      File "/home/mg/.venv/local/lib/python2.7/site-packages/urwid/main_loop.py", line 444, in _run_screen_event_loop
        keys = self.input_filter(keys, raw)
      File "/home/mg/.venv/local/lib/python2.7/site-packages/urwid/main_loop.py", line 547, in input_filter
        return self._input_filter(keys, raw)
      File "/home/mg/src/urlscan/urlscan/urlchoose.py", line 106, in handle_keys
        if os.environ['BROWSER'] not in ['elinks', 'links', 'w3m', 'lynx']:
      File "/home/mg/.venv/lib/python2.7/UserDict.py", line 40, in __getitem__
        raise KeyError(key)
    KeyError: 'BROWSER'