### PR TITLE
Improved handling of multipart messages using 8bit content-transfer-encoding and stray end tag tolerance

### DIFF
--- a/urlscan/urlscan.py
+++ b/urlscan/urlscan.py
@@ -460,6 +460,23 @@ def decode_bytes(byt, enc='utf-8'):
     return strg
 
 
+def decode_msg(msg, enc='utf-8'):
+    """
+    Decodes a message fragment.
+
+    Args: msg - A Message object representing the fragment
+          enc - The encoding to use for decoding the message
+    """
+    # We avoid the get_payload decoding machinery for raw
+    # content-transfer-encodings potentially containing non-ascii characters,
+    # such as 8bit or binary, as these are encoded using raw-decode-escape which
+    # seems to prevent subsequent utf-8 decoding.
+    cte = str(msg.get('content-transfer-encoding', '')).lower()
+    decode = cte != "8bit" and cte != "binary"
+    res = msg.get_payload(decode=decode)
+    return decode_bytes(res, enc)
+
+
 def msgurls(msg, urlidx=1):
     """Main entry function for urlscan.py
 
@@ -474,13 +491,13 @@ def msgurls(msg, urlidx=1):
             for chunk in msgurls(part, urlidx):
                 urlidx += 1
                 yield chunk
-    elif msg.get_content_type() == 'text/plain':
-        msg = decode_bytes(msg.get_payload(decode=True), enc)
-        for chunk in extracturls(msg):
+    elif msg.get_content_type() == "text/plain":
+        decoded = decode_msg(msg, enc)
+        for chunk in extracturls(decoded):
             urlidx += 1
             yield chunk
-    elif msg.get_content_type() == 'text/html':
-        msg = decode_bytes(msg.get_payload(decode=True), enc)
-        for chunk in extracthtmlurls(msg):
+    elif msg.get_content_type() == "text/html":
+        decoded = decode_msg(msg, enc)
+        for chunk in extracthtmlurls(decoded):
             urlidx += 1
             yield chunk

--- a/urlscan/urlscan.py
+++ b/urlscan/urlscan.py
@@ -472,7 +472,7 @@ def decode_msg(msg, enc='utf-8'):
     # such as 8bit or binary, as these are encoded using raw-unicode-escape which
     # seems to prevent subsequent utf-8 decoding.
     cte = str(msg.get('content-transfer-encoding', '')).lower()
-    decode = cte != "8bit" and cte != "binary"
+    decode = cte not in ("8bit", "7bit", "binary")
     res = msg.get_payload(decode=decode)
     return decode_bytes(res, enc)
 

--- a/urlscan/urlscan.py
+++ b/urlscan/urlscan.py
@@ -184,14 +184,18 @@ class HTMLChunker(HTMLParser):
 
     def handle_endtag(self, tag):
         if tag == 'a':
-            del self.anchor_stack[-1]
+            if len(self.anchor_stack) > 1:
+                del self.anchor_stack[-1]
         elif tag in HTMLChunker.tag_styles:
-            del self.style_stack[-1]
+            if len(self.style_stack) > 1:
+                del self.style_stack[-1]
         elif tag in ('ul', 'ol'):
-            del self.list_stack[-1]
+            if len(self.list_stack) > 0:
+                del self.list_stack[-1]
             self.end_para()
         elif isheadertag(tag):
-            del self.style_stack[-1]
+            if len(self.style_stack) > 1:
+                del self.style_stack[-1]
             self.end_para()
         elif tag in ('style', 'script'):
             self.in_style_or_script = False

--- a/urlscan/urlscan.py
+++ b/urlscan/urlscan.py
@@ -469,7 +469,7 @@ def decode_msg(msg, enc='utf-8'):
     """
     # We avoid the get_payload decoding machinery for raw
     # content-transfer-encodings potentially containing non-ascii characters,
-    # such as 8bit or binary, as these are encoded using raw-decode-escape which
+    # such as 8bit or binary, as these are encoded using raw-unicode-escape which
     # seems to prevent subsequent utf-8 decoding.
     cte = str(msg.get('content-transfer-encoding', '')).lower()
     decode = cte != "8bit" and cte != "binary"


### PR DESCRIPTION
I have been getting the following stack trace when opening some messages using urlscan

```
Traceback (most recent call last):
  File "/usr/bin/urlscan", line 169, in <module>
    dedupe=args.dedupe)
  File "/usr/lib/python3.7/site-packages/urlscan/urlchoose.py", line 131, in __init__
    shorten=self.shorten)
  File "/usr/lib/python3.7/site-packages/urlscan/urlchoose.py", line 64, in process_urls
    for group, usedfirst, usedlast in extractedurls:
  File "/usr/lib/python3.7/site-packages/urlscan/urlscan.py", line 432, in msgurls
    for chunk in msgurls(part, urlidx):
  File "/usr/lib/python3.7/site-packages/urlscan/urlscan.py", line 442, in msgurls
    for chunk in extracthtmlurls(msg):
  File "/usr/lib/python3.7/site-packages/urlscan/urlscan.py", line 410, in extracthtmlurls
    c.feed(s)
  File "/usr/lib64/python3.7/html/parser.py", line 111, in feed
    self.goahead(0)
  File "/usr/lib64/python3.7/html/parser.py", line 163, in goahead
    self.handle_data(unescape(rawdata[i:j]))
  File "/usr/lib/python3.7/site-packages/urlscan/urlscan.py", line 200, in handle_data
    if self.anchor_stack[-1] is None:
IndexError: list index out of range
```

While the crashes that I experience always seem to originate from that line of code, there seem to be two different root causes both of which are addressed by this PR.

1. Some HTML message bodies simply contain too many end tags which causes the stacks in `HTMLChunker` to empty. To avoid this, we guard the stack popping in `handle_endtag` to prevent the stacks from emptying. This is not a perfect workaround, but it is preferable to crashing.
2. For message parts using a raw `content-transfer-encoding` (`8bit` or `binary`) we avoid the decoding machinery of the `msg_payload` function. This is because the `msg_payload` function will encode raw message bodies containing non-ascii characters using the `raw-unicode-escape` encoding which cannot be subsequently decoded as `utf-8`. This causes a `UnicodeDecodeError` to be thrown in the `decode_bytes` function which means that the `"Unable to deocde message"...` is passed on to `extracthtmlurls`.