### PR TITLE
add option to pipe URL into external command

### DIFF
--- a/bin/urlscan
+++ b/bin/urlscan
@@ -55,6 +55,9 @@ def parse_arguments():
                            "instead of opening URL in browser. Use {} to "
                            "represent the URL value in the expression. "
                            "For example: --run 'echo {} | xclip -i'")
+    arg_parse.add_argument('--pipe', '-p', dest='pipe',
+                           action='store_true', default=False,
+                           help='Pipe URL into the command specified by --run')
     arg_parse.add_argument('message', nargs='?', default=sys.stdin,
                            help="Filename of the message to parse")
     return arg_parse.parse_args()
@@ -174,7 +177,8 @@ def main():
         tui = urlchoose.URLChooser(urlscan.msgurls(msg),
                                    compact=args.compact,
                                    dedupe=args.dedupe,
-                                   run=args.run)
+                                   run=args.run,
+                                   pipe=args.pipe)
         tui.main()
     else:
         out = urlchoose.URLChooser(urlscan.msgurls(msg),

--- a/urlscan/urlchoose.py
+++ b/urlscan/urlchoose.py
@@ -23,7 +23,7 @@ import json
 import os
 from os.path import dirname, exists, expanduser
 import re
-from subprocess import Popen
+from subprocess import Popen, PIPE
 from threading import Thread
 from time import sleep
 import webbrowser
@@ -90,7 +90,7 @@ def splittext(text, search, attr):
 class URLChooser:
 
     def __init__(self, extractedurls, compact=False, dedupe=False, shorten=True,
-                 run=""):
+                 run="", pipe=False):
         self.conf = expanduser("~/.config/urlscan/config.json")
         self.palettes = []
         try:
@@ -124,6 +124,7 @@ class URLChooser:
         self.shorten = shorten
         self.compact = compact
         self.run = run
+        self.pipe = pipe
         self.search = False
         self.search_string = ""
         self.no_matches = False
@@ -462,8 +463,13 @@ class URLChooser:
                     self.enter = False
             elif not self.run:
                 webbrowser.open(url)
+            elif self.run and self.pipe:
+                process = Popen(self.run.format(url), shell=True, stdin=PIPE)
+                process.communicate(input=url.encode('utf8'))
+
             else:
                 Popen(self.run.format(url), shell=True).communicate()
+
             size = self.tui.get_cols_rows()
             self.draw_screen(size)
         return browse


### PR DESCRIPTION
This is useful because URLs may contain characters that are interpreted by the shell, which may prevent the command specified with --run from working.
This way the url never sees the URL and cannot mess anything up.