### PR TITLE
Allow $ as an acceptable trailing character

### DIFF
--- a/urlscan/urlscan.py
+++ b/urlscan/urlscan.py
@@ -255,7 +255,7 @@ class HTMLChunker(HTMLParser):
 
 
 URLINTERNALPATTERN = r'[{}()@\w/\\\-%?!&.=:;+,#~]'
-URLTRAILINGPATTERN = r'[{}(@\w/\-%&=+#]'
+URLTRAILINGPATTERN = r'[{}(@\w/\-%&=+#$]'
 HTTPURLPATTERN = (r'(?:(https?|file|ftps?)://' + URLINTERNALPATTERN +
                   r'*' + URLTRAILINGPATTERN + r')')
 # Used to guess that blah.blah.blah.TLD is a URL.


### PR DESCRIPTION
My company has recently started using a URL defense service that
encapsulates email URLs and routes them to a URL filtering service.
These URLs also include a checksum that always ends with a $ character.

urlscan does not currently recognize the $ as part of a link and
therefore removes it, invalidating the checksum and giving me an error
in the URL defense service. By including the $ as an acceptable
character, I can now successfully use email links with mutt and the new
service.