### PR TITLE
add option for custom regex

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,10 @@ Relative to urlview, urlscan has the following additional features:
 
 - Show complete help menu with `F1`. Hide header on startup with `--nohelp`.
 
+- Use a custom regular expression with `-E` for matching urls or any
+  other pattern. In junction with `-r`, this effectively turns urlscan
+  into a general purpose CLI selector-type utility.
+
 Installation and setup
 ----------------------
 
@@ -102,7 +106,7 @@ Command Line usage
 
 ::
 
-    urlscan [-g, --genconf] [-n, --no-browser] [-c, --compact] [-d, --dedupe] [-r, --run <expression>] [-R, --reverse] [-s, --single] [-p, --pipe] [-w, --width] [-H, --nohelp] <file>
+    urlscan [-g, --genconf] [-n, --no-browser] [-c, --compact] [-d, --dedupe] [-r, --run <expression>] [-R, --reverse] [-s, --single] [-p, --pipe] [-w, --width] [-H, --nohelp] [-E, --regex <expression>] <file>
 
 Urlscan can extract URLs and email addresses from emails or any text file.
 Calling with no flags will start the curses browser. Calling with '-n' will just

--- a/bin/urlscan
+++ b/bin/urlscan
@@ -56,6 +56,10 @@ def parse_arguments():
     arg_parse.add_argument('--dedupe', '-d', dest="dedupe",
                            action='store_true', default=False,
                            help="Remove duplicate URLs from list")
+    arg_parse.add_argument('--regex', '-E',
+                           help="Alternate custom regex to be used for all "
+                           "kinds of matching. "
+                           "For example: --regex 'https?://.+\.\w+'")
     arg_parse.add_argument('--run', '-r',
                            help="Alternate command to run on selected URL "
                            "instead of opening URL in browser. Use {} to "
@@ -192,7 +196,7 @@ def main():
         return
     msg = process_input(args.message)
     if args.nobrowser is False:
-        tui = urlchoose.URLChooser(urlscan.msgurls(msg),
+        tui = urlchoose.URLChooser(urlscan.msgurls(msg, regex=args.regex),
                                    compact=args.compact,
                                    reverse=args.reverse,
                                    nohelp=args.nohelp,
@@ -203,7 +207,7 @@ def main():
                                    pipe=args.pipe)
         tui.main()
     else:
-        out = urlchoose.URLChooser(urlscan.msgurls(msg),
+        out = urlchoose.URLChooser(urlscan.msgurls(msg, regex=args.regex),
                                    dedupe=args.dedupe,
                                    reverse=args.reverse,
                                    shorten=False)

--- a/urlscan.1
+++ b/urlscan.1
@@ -109,7 +109,7 @@ Set display width.
 .B \-E, \-\-regex \<expression\>
 Use \<expression\> in place of the default set of regular expressions,
 to be used for any kind of matching. This is useful for example when
-selectively avoiding 'mailto:' links or any other patterns that urlscan
+selectively avoiding 'mailto:' links or any other pattern that urlscan
 could interpret as urls (such as '<filename>.<extension>'). Usage
 example:
 

--- a/urlscan.1
+++ b/urlscan.1
@@ -14,8 +14,8 @@ urlscan \- browse the URLs in an email message from a terminal
 .SH DESCRIPTION
 \fBurlscan\fR accepts a single email message on standard
 input, then displays a terminal-based list of the URLs in the given
-message.  Selecting a URL uses the Python webbrowser module to 
-determine which browser to open. The \fBBROWSER\fR environment 
+message.  Selecting a URL uses the Python webbrowser module to
+determine which browser to open. The \fBBROWSER\fR environment
 variable will be used if it is set.
 
 \fBurlscan\fR is primarily intended to be used with the
@@ -105,6 +105,15 @@ Exit urlscan after opening or copying a single browser link.
 .TP
 .B \-w, \-\-width
 Set display width.
+.TP
+.B \-E, \-\-regex \<expression\>
+Use \<expression\> in place of the default set of regular expressions,
+to be used for any kind of matching. This is useful for example when
+selectively avoiding 'mailto:' links or any other patterns that urlscan
+could interpret as urls (such as '<filename>.<extension>'). Usage
+example:
+
+    $ urlscan --regex 'https?://.+\.\w+' file.txt
 
 .SH MUTT INTEGRATION
 

--- a/urlscan/urlscan.py
+++ b/urlscan/urlscan.py
@@ -428,7 +428,7 @@ def extracturls(mesg, regex=None):
                                 1, 1)
 
 
-def extracthtmlurls(mesg, regex=None):
+def extracthtmlurls(mesg):
     """Extract URLs with context from html type message. Similar to extracturls.
 
     """
@@ -502,6 +502,6 @@ def msgurls(msg, urlidx=1, regex=None):
             yield chunk
     elif msg.get_content_type() == "text/html":
         decoded = decode_msg(msg, enc)
-        for chunk in extracthtmlurls(decoded, regex=regex):
+        for chunk in extracthtmlurls(decoded):
             urlidx += 1
             yield chunk


### PR DESCRIPTION
As discussed in #79.

Users can now provide a custom regular expression to be used instead of default expressions.

```
  --regex REGEX, -E REGEX
                        Alternate custom regex to be used for all kinds of
                        matching. For example: --regex 'https?://.+\.\w+'
```