### PR TITLE
User-option -W --whitespace-off: remove blank lines and ellipses

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,15 +109,16 @@ Command Line usage
 
 ::
 
-    urlscan [-g, --genconf] [-n, --no-browser] [-c, --compact] [-d, --dedupe] [--headers] [-r, --run <expression>] [-f, --run-safe <expression>] [-R, --reverse] [-s, --single] [-p, --pipe] [-w, --width] [-H, --nohelp] [-E, --regex <expression>] <file>
+    urlscan [-g, --genconf] [-n, --no-browser] [-c, --compact] [-d, --dedupe] [--headers] [-r, --run <expression>] [-f, --run-safe <expression>] [-R, --reverse] [-s, --single] [-p, --pipe] [-w, --width] [-H, --nohelp] [-E, --regex <expression>] [-W -whitespace-off] <file>
 
 Urlscan can extract URLs and email addresses from emails or any text file.
 Calling with no flags will start the curses browser. Calling with '-n' will just
 output a list of URLs/email addressess to stdout. The '-c' flag removes the
 context from around the URLs in the curses browser, and the '-d' flag removes
-duplicate URLs. 'R' reverses the displayed order of URLs and context. Files can
-also be piped to urlscan using normal shell pipe mechanisms: `cat <something> |
-urlscan` or `urlscan < <something>`
+duplicate URLs. The '-R' flag reverses the displayed order of URLs and context.
+Files can also be piped to urlscan using normal shell pipe mechanisms: `cat
+<something> | urlscan` or `urlscan < <something>`. The '-W' flag condenses the
+display output by suppressing blank lines and ellipses lines.
 
 Instead of opening a web browser, the selected URL can be passed as the argument
 to a command using `--run-safe "<command> {}"` or `--run "<command> {}"`. Note

--- a/bin/urlscan
+++ b/bin/urlscan
@@ -80,6 +80,9 @@ def parse_arguments():
     arg_parse.add_argument('--width', '-w', dest='width',
                            type=int, default=0,
                            help='Set width to display')
+    arg_parse.add_argument('--whitespace-off', '-W', dest='whitespaceoff',
+                           action='store_true', default=False,
+                           help="Don't display empty lines and ellipses.")
     arg_parse.add_argument('--headers', dest='headers',
                            action='store_true', default=False,
                            help='Scan certain message headers for URLs.')
@@ -171,6 +174,7 @@ def main():
                                    runsafe=args.runsafe,
                                    single=args.single,
                                    width=args.width,
+                                   whitespaceoff=args.whitespaceoff,
                                    pipe=args.pipe)
         tui.main()
     else:

--- a/urlscan.1
+++ b/urlscan.1
@@ -128,6 +128,10 @@ example:
 .B \-\-headers
 Scan email headers for URLs.
 
+.TP
+.B \-W, \-\-whitespace-off
+Suppress output of blank lines and ellipses lines.
+
 .SH MUTT INTEGRATION
 
 To integrate urlscan with mutt, include the following two commands in

--- a/urlscan/urlchoose.py
+++ b/urlscan/urlchoose.py
@@ -93,7 +93,7 @@ class URLChooser:
 
     def __init__(self, extractedurls, compact=False, reverse=False, nohelp=False, dedupe=False,
                  shorten=True, run="", runsafe="", single=False, pipe=False,
-                 genconf=False, width=0):
+                 genconf=False, width=0, whitespaceoff=False):
         self.conf = expanduser("~/.config/urlscan/config.json")
         self.keys = {'/': self._search_key,
                      '0': self._digits,
@@ -188,6 +188,7 @@ class URLChooser:
         self.enter = False
         self.term_width, _ = urwid.raw_display.Screen().get_cols_rows()
         self.width = min(self.term_width, width or self.term_width)
+        self.whitespaceoff = whitespaceoff
         self.activate_keys = [i for i, j in urwid.Button._command_map._command.items()
                               if j == 'activate']
         self.items, self.urls = self.process_urls(extractedurls,
@@ -707,7 +708,7 @@ class URLChooser:
                     continue
             groupurls = []
             markup = []
-            if not usedfirst:
+            if not usedfirst and not self.whitespaceoff:
                 markup.append(('msgtext:ellipses', '...\n'))
             for chunks in group:
                 i = 0
@@ -736,8 +737,9 @@ class URLChooser:
                                    ('urlref:number:braces', ' ['),
                                    ('urlref:number', repr(url_idx)),
                                    ('urlref:number:braces', ']')]
-                markup += '\n'
-            if not usedlast:
+                if not self.whitespaceoff:
+                    markup += '\n'
+            if not usedlast and not self.whitespaceoff:
                 markup += [('msgtext:ellipses', '...\n\n')]
             items.append(urwid.Text(markup))
 


### PR DESCRIPTION
I originally wrote this for version 0.9.4 where some renderings had many consecutive lines of white-space. After upgrading to 0.9.6 in order to make the PR, I see that has been greatly reduced but I still like the compact look so I'm offering it as an option. I failed in an attempt to write a run-time toggle option for this feature.