### PR TITLE
Correct regex example in urlscan.1

### DIFF
--- a/urlscan.1
+++ b/urlscan.1
@@ -123,7 +123,7 @@ selectively avoiding 'mailto:' links or any other pattern that urlscan
 could interpret as urls (such as '<filename>.<extension>'). Usage
 example:
 
-    $ urlscan --regex 'https?://.+\.\w+' file.txt
+    $ urlscan --regex 'https?://.+\.\\w+' file.txt
 .TP
 .B \-\-headers
 Scan email headers for URLs.


### PR DESCRIPTION
`\w` in example of -E/--regex option is wrongly evaluated and needs escaping