### PR TITLE
Fix muttrc snipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ from Pypi, or do a local development install with pip -e:
 
 Once urlscan is installed, add the following lines to your .muttrc:
 
-    macro index,pager \\cb "<pipe-message> urlscan<Enter>" "call urlscan to
+    macro index,pager \cb "<pipe-message> urlscan<Enter>" "call urlscan to
     extract URLs out of a message"
 
-    macro attach,compose \\cb "<pipe-entry> urlscan<Enter>" "call urlscan to
+    macro attach,compose \cb "<pipe-entry> urlscan<Enter>" "call urlscan to
     extract URLs out of a message"
 
 Once this is done, Control-b while reading mail in mutt will automatically


### PR DESCRIPTION
Thanks for urlscan!

I just enabled it in my mutt installation and saw that the snipped in READE.md has "\\c"  instead of "\c", so when pasting the lines into the muttrc it will not bind to Ctrl+B but to \cb  (as displayed by mutts internal help). 
A single backslash fixed that for me, so thie PR updated the documentation.

-- 
tobi