### PR TITLE
Include manpage in source distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,5 @@ LICENSE = "share/doc/urlscan/LICENSE"
 [tool.hatch.build.targets.sdist]
 include = [
     "/urlscan",
+    "urlscan.1",
 ]


### PR DESCRIPTION
This used to be the case before but changed during the hatch transition.