### PR TITLE
fix: patch invalid escape sequence in regex argument help text to support py3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Utilities",
 ]
 dependencies = [

--- a/urlscan/__main__.py
+++ b/urlscan/__main__.py
@@ -56,7 +56,7 @@ def parse_arguments():
     arg_parse.add_argument('--regex', '-E',
                            help="Alternate custom regex to be used for all "
                            "kinds of matching. "
-                           "For example: --regex 'https?://.+\.\w+'")
+                           r"For example: --regex 'https?://.+\.\w+'")
     arg_parse.add_argument('--run', '-r',
                            help="Alternate command to run on selected URL "
                            "instead of opening URL in browser. Use {} to "


### PR DESCRIPTION


```
==> /opt/homebrew/Cellar/urlscan/1.0.1/bin/urlscan -nc
/opt/homebrew/Cellar/urlscan/1.0.1/libexec/lib/python3.12/site-packages/urlscan/__main__.py:59: SyntaxWarning: invalid escape sequence '\.'
  "For example: --regex 'https?://.+\.\w+'")
```

- https://github.com/Homebrew/homebrew-core/pull/158981