### PR TITLE
Fixes macOS piping error by forcing urwid to use SelectSelectors

### DIFF
--- a/urlscan/urlchoose.py
+++ b/urlscan/urlchoose.py
@@ -36,6 +36,8 @@ import urwid
 if platform == 'darwin':
     COPY_COMMANDS = ('pbcopy',)
     COPY_COMMANDS_PRIMARY = ('pbcopy',)
+    import selectors
+    selectors.DefaultSelector = selectors.SelectSelector
 elif 'WAYLAND_DISPLAY' in os.environ:
     COPY_COMMANDS = ('wl-copy',)
     COPY_COMMANDS_PRIMARY = ('wl-copy --primary',)


### PR DESCRIPTION
fixes: https://github.com/firecat53/urlscan/issues/155
see: https://github.com/urwid/urwid/issues/1025

piping with urlscan was broken on macOS due to issues with selectors.KqueueSelector, which is the default on macOS.

This overrides the default on macOS to fix the problem.